### PR TITLE
Agregar redux y redux/toolkit para manejo de estado global

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,14 @@
       "name": "ecommerce",
       "version": "0.1.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^2.3.0",
         "axios": "^1.7.7",
         "json-server": "^1.0.0-beta.3",
         "next": "15.0.2",
         "react": "18.3.0",
-        "react-dom": "18.3.0"
+        "react-dom": "18.3.0",
+        "react-redux": "^9.1.2",
+        "redux": "^5.0.1"
       },
       "devDependencies": {
         "eslint": "^8",
@@ -815,6 +818,30 @@
       "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.3.0.tgz",
+      "integrity": "sha512-WC7Yd6cNGfHx8zf+iu+Q1UPTfEcXhQ+ATi7CV1hlrSAaQBdlPzg7Ww/wJHNQem7qG9rxmWoFCDCPubSvFObGzA==",
+      "license": "MIT",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1087,6 +1114,12 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1928,9 +1961,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3368,6 +3401,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -5009,6 +5052,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.2.tgz",
+      "integrity": "sha512-0OA4dhM1W48l3uzmv6B7TXPCGmokUU4p1M44DGN2/D9a1FjVPukVjER1PcPX97jIg6aUeLq1XJo1IpfbgULn0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25",
+        "react": "^18.0",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -5030,6 +5096,21 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5081,6 +5162,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -6053,6 +6140,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -10,11 +10,14 @@
     "api": "json-server --port 5000 --watch src/app/db/db.json"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^2.3.0",
     "axios": "^1.7.7",
     "json-server": "^1.0.0-beta.3",
     "next": "15.0.2",
     "react": "18.3.0",
-    "react-dom": "18.3.0"
+    "react-dom": "18.3.0",
+    "react-redux": "^9.1.2",
+    "redux": "^5.0.1"
   },
   "devDependencies": {
     "eslint": "^8",

--- a/src/app/(features)/products/hooks/useProducts.js
+++ b/src/app/(features)/products/hooks/useProducts.js
@@ -1,25 +1,16 @@
-import { useEffect, useState } from "react";
-import { getProducts } from "../services/productService";
+'use client';
+
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { fetchProductsThunk } from "../slices/thunks";
 
 export const useProducts = (categoryId = '') => {
-  const [products, setProducts] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-
-  const loadProducts = async () => {
-    try {
-      const data = await getProducts(categoryId);
-      setProducts(data);
-    } catch (error) {
-      setError(error.message);
-    } finally {
-      setLoading(false);
-    }
-  };
+  const dispatch = useDispatch();
+  const { products, isLoading, error } = useSelector((state) => state.products);
 
   useEffect(() => {
-    loadProducts();
+    dispatch(fetchProductsThunk(categoryId));
   }, [categoryId]); //volver a consultar los productos si cambia la categoria
 
-  return { products, loading, error };
-}
+  return { products, isLoading, error };
+};

--- a/src/app/(features)/products/page.js
+++ b/src/app/(features)/products/page.js
@@ -7,13 +7,13 @@ import { useProducts } from "./hooks/useProducts";
 const ProductsPage = () => {
   const searchParams = useSearchParams();
   const categoryId = searchParams.get('categoryId') || ''; // obtengo el parámetro desde la URL
-  const { products, loading, error } = useProducts(categoryId);
+  const { products, isLoading, error } = useProducts(categoryId);
 
   return (
     <>
-      {loading && <p>Loading...</p>}
+      {isLoading && <p>Loading...</p>}
       {error && <p>Error: {error}</p>}
-      {!loading && !error && <ProductsList products={products} />}
+      {!isLoading && !error && <ProductsList products={products} />}
     </>
   );
 };

--- a/src/app/(features)/products/services/productService.js
+++ b/src/app/(features)/products/services/productService.js
@@ -1,8 +1,12 @@
 import axios from "axios";
 
-export const getProducts = async (categoryId = '') => {
-  const response = await axios.get(`http://localhost:5000/products`, {
-    params: categoryId ? { categoryId } : {}, //se agrega el parámetro para filtrar por categoria
-  });
-  return response.data;
+export const fetchProducts = async (categoryId = '') => {
+  try {
+    const response = await axios.get(`http://localhost:5000/products`, {
+      params: categoryId ? { categoryId } : {}, //se agrega el parámetro para filtrar por categoria
+    });
+    return response.data;    
+  } catch (error) {
+    throw new Error(error.message);
+  }
 };

--- a/src/app/(features)/products/slices/productSlice.js
+++ b/src/app/(features)/products/slices/productSlice.js
@@ -1,0 +1,25 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+export const productsSlice = createSlice({
+    name: 'product',
+    initialState: {
+        products: [],
+        isLoading: false,
+        error: null,
+    },
+    reducers: {
+        startLoadingProducts: (state, /* action */ ) => {
+            state.isLoading = true;
+        },
+        setProducts: (state, action) => {
+            state.isLoading = false;
+            state.products = action.payload;
+            state.error = null; //Limpiar errores en caso de éxito
+        },
+        setError: (state, action) => {
+            state.error = action.payload;
+        },
+    }
+});
+// Action creators are generated for each case reducer function
+export const { startLoadingProducts, setProducts, setError } = productsSlice.actions;

--- a/src/app/(features)/products/slices/thunks.js
+++ b/src/app/(features)/products/slices/thunks.js
@@ -1,0 +1,12 @@
+import { fetchProducts } from "../services/productService";
+import { setProducts, startLoadingProducts, setError } from "./productSlice";
+
+export const fetchProductsThunk = (categoryId='') => async (dispatch) => {
+    try {
+        dispatch(startLoadingProducts(true));
+        const products = await fetchProducts(categoryId);
+        dispatch(setProducts(products));
+    } catch (error) {
+        dispatch(setError(error.message));
+    }
+}

--- a/src/app/clientProvider.js
+++ b/src/app/clientProvider.js
@@ -1,0 +1,11 @@
+"use client";
+
+import React from "react";
+import { Provider } from "react-redux";
+import { store } from "./store/store";
+
+const ClientProvider = ({ children }) => {
+  return <Provider store={store}>{children}</Provider>;
+};
+
+export default ClientProvider;

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,3 +1,4 @@
+import ClientProvider from "./clientProvider";
 import Footer from "./components/footer/Footer";
 import Header from "./components/header/Header";
 import "./globals.css";
@@ -11,9 +12,11 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body>
-        <Header />
-        {children}
-        <Footer />
+        <ClientProvider>
+          <Header />
+          {children}
+          <Footer />
+        </ClientProvider>
       </body>
     </html>
   );

--- a/src/app/store/store.js
+++ b/src/app/store/store.js
@@ -1,0 +1,8 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { productsSlice } from "../(features)/products/slices/productSlice";
+
+export const store = configureStore({
+  reducer: {
+    products: productsSlice.reducer,
+  },
+});


### PR DESCRIPTION
Se agregó redux y redux toolkit para manejo de estado global.
Los productos ahora se manejan con redux
Tambien se agregó el archivo clientProvider.js como wrapper manejar el store con redux en nextjs, sino tiraba error al querer usar en el rootLayout metadata y ademas la directiva 'use client'.